### PR TITLE
Feature images

### DIFF
--- a/src/main/java/com/google/codeu/data/Datastore.java
+++ b/src/main/java/com/google/codeu/data/Datastore.java
@@ -103,12 +103,16 @@ public class Datastore {
 
         UUID id = UUID.fromString(idString);    
         String user = (String) entity.getProperty("user");
-        String text = (String) entity.getProperty("text");  
         String recipient = (String) entity.getProperty("recipient");
-        
         long timestamp = (long) entity.getProperty("timestamp");
-
-        Message message = new Message(id, user, text, timestamp, recipient);
+        
+        // Replace all image URLS in message with proper image HTML tags
+        String text = (String) entity.getProperty("text");
+        String regex = "(https?://([^\\s.]+.?[^\\s.]*)+/[^\\s.]+.(png|jpg))";
+        String replacement = "<img src=\"$1\" />";
+        String textWithImagesReplaced = text.replaceAll(regex, replacement);
+        
+        Message message = new Message(id, user, textWithImagesReplaced, timestamp, recipient);
         messages.add(message);
       } catch (Exception e) {
         System.err.println("Error reading message.");

--- a/src/main/webapp/css/user-page.css
+++ b/src/main/webapp/css/user-page.css
@@ -40,6 +40,12 @@
   margin: 5px;
 }
 
+.message-body img {
+  display: block;
+  margin-top: 25px;
+  max-width: 75%;
+}
+
 /* Use this to hide certain elements like forms if the
    user is not logged in or viewing their own page. */
 .hidden {

--- a/src/main/webapp/css/user-page.css
+++ b/src/main/webapp/css/user-page.css
@@ -40,6 +40,8 @@
   margin: 5px;
 }
 
+/* Shrinks images to fit if they are larger than
+  .message-body */
 .message-body img {
   display: block;
   margin-top: 25px;


### PR DESCRIPTION
Users can now include images in their messages by pasting valid image URLS in their messages. Images don't render until message has been posted. This works by replacing the image URL with an HTML image tag. Currently the workload is done on the server during a get request for the message.